### PR TITLE
A first pass at Arduino Boards Manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ And here it is using `analogRead()` to read the voltage over a potentiomeneter a
 ![ADC_OLED_preview](https://user-images.githubusercontent.com/26485477/122623205-81bbaa00-d09b-11eb-8195-fa5fce0c9dd3.jpg)
 
 
-## Using this core
+## Using this core with PlatformIO
 
 Currently, development of this core is being done using PlatformIO. It uses the custom PlatformIO platform https://github.com/maxgerhardt/platform-gd32. 
 
 Using PlatformIO is already possible to very easily edit code in the IDE and even live-debug a chip (with e.g. an ST-Link)
 
 Example projects for this platform for the SPL framework and this Arduino core are currently hosted at https://github.com/maxgerhardt/gd32-pio-projects, but are subject to be moved soon.
+
+## Using this core with the Arduino IDE
+
+To compile for this core with the Arduino IDE, add the following URL to the boards manager.
+
+`https://raw.githubusercontent.com/CommunityGD32Cores/GD32Core-New/jesse/boardmgr/package_gd32_index.json`
+
+This will install the core and compiler toolchain against the 'main' git branch.
 
 ## Current state
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example projects for this platform for the SPL framework and this Arduino core a
 
 To compile for this core with the Arduino IDE, add the following URL to the boards manager.
 
-`https://raw.githubusercontent.com/CommunityGD32Cores/GD32Core-New/jesse/boardmgr/package_gd32_index.json`
+`https://raw.githubusercontent.com/CommunityGD32Cores/GD32Core-New/main/package_gd32_index.json`
 
 This will install the core and compiler toolchain against the 'main' git branch.
 

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -20,7 +20,7 @@
                "help" : {
                   "online" : ""
                },
-               "name" : "GigaDevices GD32",
+               "name" : "GigaDevice GD32",
                "toolsDependencies" : [ ],
                "url" : "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
                "version" : "0.0.1"

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -10,7 +10,7 @@
       "platforms": [
         {
           "architecture": "arm",
-          "archiveFileName": "GD32Core-New-main.zip",
+          "archiveFileName": "GD32Core-New-jesse-boardmgr.zip",
           "boards": [
             {
               "name": "GD32F303 EVAL series"
@@ -28,7 +28,7 @@
               "version": "9.3.1-1.3"
             }
           ],
-          "url": "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
+          "url": "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/jesse/boardmgr.zip",
           "version": "0.0.1"
         }
       ],

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -21,13 +21,7 @@
                   "online" : ""
                },
                "name" : "GigaDevices GD32",
-               "toolsDependencies" : [
-                  {
-                     "name" : "gcc",
-                     "packager" : "arduino",
-                     "version" : "7.3.0-atmel3.6.1-arduino7"
-                  }
-               ],
+               "toolsDependencies" : [ ],
                "url" : "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
                "version" : "0.0.1"
             }

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -1,0 +1,39 @@
+{
+   "packages" : [
+      {
+         "email" : "",
+         "help" : {
+            "online" : "https://github.com/CommunityGD32Cores/GD32Core-New"
+         },
+         "maintainer" : "Some random folks",
+         "name" : "GD32-New",
+         "platforms" : [
+            {
+               "architecture" : "arm",
+               "archiveFileName" : "GD32Core-New-main.zip",
+               "boards" : [
+                  {
+                     "name" : "GD32F303 EVAL series"
+                  }
+               ],
+               "category" : "Contributed",
+               "help" : {
+                  "online" : ""
+               },
+               "name" : "GigaDevices GD32",
+               "toolsDependencies" : [
+                  {
+                     "name" : "gcc",
+                     "packager" : "arduino",
+                     "version" : "7.3.0-atmel3.6.1-arduino7"
+                  }
+               ],
+               "url" : "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
+               "version" : "0.0.1"
+            }
+         ],
+         "tools" : [],
+         "websiteURL" : "https://github.com/CommunityGD32Cores/GD32Core-New/"
+      }
+   ]
+}

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -6,7 +6,7 @@
         "online": "https://github.com/CommunityGD32Cores/GD32Core-New"
       },
       "maintainer": "Some random folks",
-      "name": "GD32-New",
+      "name": "GD32Community",
       "platforms": [
         {
           "architecture": "arm",
@@ -23,7 +23,7 @@
           "name": "GigaDevice GD32",
           "toolsDependencies": [
             {
-	      "packager": "xpack",
+	      "packager": "GD32Community",
               "name": "xpack-arm-none-eabi-gcc",
               "version": "9.3.1-1.3"
             }

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -23,9 +23,9 @@
           "name": "GigaDevice GD32",
           "toolsDependencies": [
             {
-              "name": "arm-none-eabi-gcc",
-              "packager": "arduino",
-              "version": "9-2019q4"
+	      "packager": "xpack",
+              "name": "xpack-arm-none-eabi-gcc",
+              "version": "9.3.1-1.3"
             }
           ],
           "url": "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
@@ -34,50 +34,51 @@
       ],
       "tools": [
         {
-          "name": "arm-none-eabi-gcc",
-          "version": "9-2019q4",
-          "systems": [
+          "name": "xpack-arm-none-eabi-gcc",
+          "version": "9.3.1-1.3",
+          "systems":
+          [
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b",
-              "size": "96613739"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-arm.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-arm.tar.gz",
+              "checksum": "SHA-256:0e6720296f291141cd757d90e6bf60867a1232de9abc52b0cde28af12eeb94f2",
+              "size": "147111321"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
-              "checksum": "MD5:0dfa059aae18fcf7d842e30c525076a4",
-              "size": "128670769"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-arm64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-arm64.tar.gz",
+              "checksum": "SHA-256:9a9e96b9ac3634d7632d35aa0d8138f8468d4f3f4d752374a95420ff7c8e4476",
+              "size": "150584175"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
-              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
-              "checksum": "MD5:9d60cbb0e358ab6a9d3c9e5dc3624dd2",
-              "size": "153520070"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-win32-x32.zip",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-win32-x32.zip",
+              "checksum": "SHA-256:7432cfff045dc421d2ba177c3777ec1e82d4febe5f5f51fb2e90ff07d27cd466",
+              "size": "148593506"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
-              "checksum": "MD5:241b64f0578db2cf146034fc5bcee3d4",
-              "size": "116770520"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-darwin-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-darwin-x64.tar.gz",
+              "checksum": "SHA-256:f22f0d49c27f844dcfe629a6a33878d767b6945acd7508d9578b20b17b106f4c",
+              "size": "148641073"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
-              "checksum": "MD5:fe0029de4f4ec43cf7008944e34ff8cc",
-              "size": "116802378"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-x64.tar.gz",
+              "checksum": "SHA-256:9045d261b000d921887fc801427542eed2df1616f63a2969a2640f8be2593686",
+              "size": "151422620"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3",
-              "size": "97427309"
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.3/xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-x32.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.3-linux-x32.tar.gz",
+              "checksum": "SHA-256:1950c7b0b4e35bacec32450158ec192ac469189a5fb27c2fd7c01e9603e50e64",
+              "size": "154309058"
             }
           ]
         }

--- a/package_gd32_index.json
+++ b/package_gd32_index.json
@@ -1,33 +1,88 @@
 {
-   "packages" : [
-      {
-         "email" : "",
-         "help" : {
-            "online" : "https://github.com/CommunityGD32Cores/GD32Core-New"
-         },
-         "maintainer" : "Some random folks",
-         "name" : "GD32-New",
-         "platforms" : [
+  "packages": [
+    {
+      "email": "",
+      "help": {
+        "online": "https://github.com/CommunityGD32Cores/GD32Core-New"
+      },
+      "maintainer": "Some random folks",
+      "name": "GD32-New",
+      "platforms": [
+        {
+          "architecture": "arm",
+          "archiveFileName": "GD32Core-New-main.zip",
+          "boards": [
             {
-               "architecture" : "arm",
-               "archiveFileName" : "GD32Core-New-main.zip",
-               "boards" : [
-                  {
-                     "name" : "GD32F303 EVAL series"
-                  }
-               ],
-               "category" : "Contributed",
-               "help" : {
-                  "online" : ""
-               },
-               "name" : "GigaDevice GD32",
-               "toolsDependencies" : [ ],
-               "url" : "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
-               "version" : "0.0.1"
+              "name": "GD32F303 EVAL series"
             }
-         ],
-         "tools" : [],
-         "websiteURL" : "https://github.com/CommunityGD32Cores/GD32Core-New/"
-      }
-   ]
+          ],
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "name": "GigaDevice GD32",
+          "toolsDependencies": [
+            {
+              "name": "arm-none-eabi-gcc",
+              "packager": "arduino",
+              "version": "9-2019q4"
+            }
+          ],
+          "url": "https://github.com/CommunityGD32Cores/GD32Core-New/archive/refs/heads/main.zip",
+          "version": "0.0.1"
+        }
+      ],
+      "tools": [
+        {
+          "name": "arm-none-eabi-gcc",
+          "version": "9-2019q4",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b",
+              "size": "96613739"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
+              "checksum": "MD5:0dfa059aae18fcf7d842e30c525076a4",
+              "size": "128670769"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
+              "checksum": "MD5:9d60cbb0e358ab6a9d3c9e5dc3624dd2",
+              "size": "153520070"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
+              "checksum": "MD5:241b64f0578db2cf146034fc5bcee3d4",
+              "size": "116770520"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
+              "checksum": "MD5:fe0029de4f4ec43cf7008944e34ff8cc",
+              "size": "116802378"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3",
+              "size": "97427309"
+            }
+          ]
+        }
+      ],
+      "websiteURL": "https://github.com/CommunityGD32Cores/GD32Core-New/"
+    }
+  ]
 }

--- a/platform.txt
+++ b/platform.txt
@@ -13,7 +13,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 ## compile path/command
-compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.2.1-1.1.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.3.1-1.3.path}/bin/
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.cpp.cmd=arm-none-eabi-g++


### PR DESCRIPTION
This will install the core  in the Arduino IDE and allow sketches to build against it.

Rather than installing releases or snapshots, this installs current git master. This isn't an acceptable long-term solution, but is convenient for early dev.

To make this go with a current compiler toolchain, I had to rev the compiler target to match the currently shipped stm32duino xpack toolchain. Because of that, the package file points at the dev branch rather than main.  `package_gd32_index.json` should be updated to download main instead of jesse/boardmgr if it passes muster.